### PR TITLE
WIP - NuPIC.cpp ARM64 build on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 version: 2
 jobs:
+
+  # job: Darwin (build-and-test)
   build-and-test:
     macos:
       xcode: '10.1.0'
@@ -22,13 +24,12 @@ jobs:
           name: Restoring system python
           command: |
             echo 'python version: ' && python --version
-            echo 'pip version: ' && python -m pip --version 
+            echo 'pip version: ' && python -m pip --version
             echo 'python version: ' && python --version
       - run:
-          name: Installing cmake 
+          name: Installing cmake
           command: brew install cmake || brew install cmake
       - checkout
-
       # Dependencies
       # Restore the dependency cache
       #      - restore_cache:
@@ -37,21 +38,19 @@ jobs:
       #    - v1-dep-{{ .Branch }}-
       #    # Default branch if not
       #    - v1-dep-master-
-      #    # Any branch if there are none on the default branch - this should be 
+      #    # Any branch if there are none on the default branch - this should be
       #    # unnecessary if you have your default branch configured correctly
       #    - v1-dep-
-
       - run:
            name: Installing python dependencies
            command: |
                    python -m pip install --user --upgrade pip setuptools setuptools-scm
                    python -m pip install --no-cache-dir --user -r bindings/py/packaging/requirements.txt  --verbose || exit
-
       # Save dependency cache
       #      - save_cache:
       #    key: v1-dep-{{ .Branch }}-{{ epoch }}
       #    paths:
-      #    # This is a broad list of cache paths to include many possible 
+      #    # This is a broad list of cache paths to include many possible
       #    # development environments.
       #    - vendor/bundle
       #    - ~/virtualenvs
@@ -61,8 +60,7 @@ jobs:
       #    - ~/.go_workspace
       #    - ~/.gradle
       #    - ~/.cache/bower
-
-      # Build 
+      # Build
       - run:
           name: Compiling
           environment:
@@ -70,14 +68,12 @@ jobs:
           command: |
             mkdir -p build/scripts
             cd build/scripts
-            cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../Release 
+            cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../Release
             make | grep -v -F '\\-\\- Installing:'
             make install 2>&1 | grep -v -F 'Installing:'
-       
       - run:
            name: Install Python extension
            command: python setup.py install --user --prefix=
-
       # Test
       - run:
           name: Running C++ Tests
@@ -88,21 +84,16 @@ jobs:
       - run:
           name: Running python tests
           command: python setup.py test
-
-
       - store_test_results:
           path: tests
-    
       - store_artifacts:
           path: dist/*.whl
-        
       ##- persist_to_workspace:
       ##    root: dist
       ##    paths:
       ##    - nupic.bindings*.whl
       ##    - requirements.txt
       ##    - include/nupic
-
             #  deploy-s3:
             #machine: true
             #steps:
@@ -115,8 +106,29 @@ jobs:
             #tar -zcv -f nupic_core-${CIRCLE_SHA1}-darwin64.tar.gz dist
             #aws s3 cp nupic_core-${CIRCLE_SHA1}-darwin64.tar.gz s3://artifacts.numenta.org/numenta/nupic.core/circle/
 
+  # job: ARM64 (arm64)
+  arm64:
+    docker:
+      - image: circleci/buildpack-deps:18.10
+    steps:
+      - run:
+          command: |
+            if [[ $CIRCLE_SHELL_ENV == *"localbuild"* ]]; then
+              echo "This is a local build. Enabling sudo for docker"
+              echo sudo > ~/sudo
+            else
+              echo "This is not a local build. Disabling sudo for docker"
+              touch ~/sudo
+            fi
+      - run: sudo apt-get -y install qemu-system
+      - checkout
+      - setup_remote_docker
+      - run: eval `cat ~/sudo` docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - run: eval `cat ~/sudo` docker build .
+
 workflows:
   version: 2
   build-test-deploy:
     jobs:
       - build-and-test
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:14.04
-
+#FROM ubuntu:18.04
+FROM multiarch/ubuntu-core:arm64-bionic
 RUN apt-get update && \
     apt-get install -y \
     curl \
@@ -22,17 +22,18 @@ RUN pip install wheel
 ENV CC gcc
 ENV CXX g++
 
-ADD . /usr/local/src/nupic.core
+ADD . /usr/local/src/nupic.cpp
 
-WORKDIR /usr/local/src/nupic.core
+WORKDIR /usr/local/src/nupic.cpp
 
 # Explicitly specify --cache-dir, --build, and --no-clean so that build
 # artifacts may be extracted from the container later.  Final built python
-# packages can be found in /usr/local/src/nupic.core/bindings/py/dist
+# packages can be found in /usr/local/src/nupic.cpp/bindings/py/dist
 
 RUN pip install \
-        --cache-dir /usr/local/src/nupic.core/pip-cache \
-        --build /usr/local/src/nupic.core/pip-build \
+        --cache-dir /usr/local/src/nupic.cpp/pip-cache \
+        --build /usr/local/src/nupic.cpp/pip-build \
         --no-clean \
-        -r bindings/py/requirements.txt && \
+        -r bindings/py/packaging/requirements.txt && \
     python setup.py bdist bdist_dumb bdist_wheel sdist
+


### PR DESCRIPTION
Work in Progress.
WIP - NuPIC ARM64 build on CircleCI
https://github.com/htm-community/nupic.cpp/issues/134

* Moving CircleCI from old 1.x config style (`./circle.yml`) to the
  newer 2.x style (`./.circleci/config.yml`).
* Adding a 2nd job to the existing CircleCI config (Darwin), to try and
  build an ARM64 Docker build.
* Updates to Dockerfile for `nupic.cpp` instead of older `nupic.core`.
* Removed empty orphan space chars in config file

With these changes (so far), one can start a local CircleCI build of
NuPIC Docker on ARM64:

```bash
# developing on mac os/x
brew install circleci
cd nupic.cpp/
circleci local execute --job arm64
```

We get to our first error (which seems like the kind of error I'd expect going
from `x86_64` -> `arm64`) below. I have no idea what to do with it, though:

```
[ 63%] Building CXX object src/test/CMakeFiles/unit_tests.dir/unit/ntypes/BasicTypeTest.cpp.o
/usr/local/src/nupic.cpp/src/test/unit/ntypes/BasicTypeTest.cpp:115:49: error: narrowing conversion of '-128' from 'int' to 'nupic::Byte {aka char}' inside { } [-Wnarrowing]
   Byte bufByte[8] = {0, 1, 2, 3, 4, 5, -128, 127};
                                                 ^
src/test/CMakeFiles/unit_tests.dir/build.make:521: recipe for target 'src/test/CMakeFiles/unit_tests.dir/unit/ntypes/BasicTypeTest.cpp.o' failed
make[2]: *** [src/test/CMakeFiles/unit_tests.dir/unit/ntypes/BasicTypeTest.cpp.o] Error 1
CMakeFiles/Makefile2:436: recipe for target 'src/test/CMakeFiles/unit_tests.dir/all' failed
make[1]: *** [src/test/CMakeFiles/unit_tests.dir/all] Error 2
Makefile:151: recipe for target 'all' failed
make: *** [all] Error 2
setup.py: Calling /usr/local/src/nupic.cpp/bindings/py/packaging/setup.py
```

cc @breznak